### PR TITLE
Fix/mongoose discriminator overwrite

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.3] - 2024-10-21
+
+### Fixed
+
+- Prevented Mongoose discriminators from being redefined, avoiding errors by checking if they already exist before defining them.
+
 ## [6.0.2] - 2024-10-21
 
 ### Fixed

--- a/src/models/rewards.ts
+++ b/src/models/rewards.ts
@@ -40,8 +40,10 @@ const rewardSchema = new Schema<RewardAttributes>(
 export const RewardModel =
   mongoose.models.Reward || model<RewardAttributes>('Reward', rewardSchema);
 
+let DigitalAssetRewardModel, InGameRewardModel;
+
 if (!RewardModel.discriminators || !RewardModel.discriminators[RewardTypes.DIGITAL_ASSET]) {
-  RewardModel.discriminator<DigitalAssetRewardDocument>(
+  DigitalAssetRewardModel = RewardModel.discriminator<DigitalAssetRewardDocument>(
     RewardTypes.DIGITAL_ASSET,
     new Schema<DigitalAssetRewardAttributes>({
       tokenId: { type: String, required: true },
@@ -52,7 +54,7 @@ if (!RewardModel.discriminators || !RewardModel.discriminators[RewardTypes.DIGIT
 }
 
 if (!RewardModel.discriminators || !RewardModel.discriminators[RewardTypes.IN_GAME_ITEM]) {
-  RewardModel.discriminator<InGameRewardDocument>(
+  InGameRewardModel = RewardModel.discriminator<InGameRewardDocument>(
     RewardTypes.IN_GAME_ITEM,
     new Schema<InGameRewardAttributes>({
       power: Number,
@@ -62,6 +64,7 @@ if (!RewardModel.discriminators || !RewardModel.discriminators[RewardTypes.IN_GA
   );
 }
 
+export { DigitalAssetRewardModel, InGameRewardModel };
 export type RewardDocument = Document & RewardAttributes;
 export type InGameRewardDocument = RewardDocument & InGameRewardAttributes;
 export type DigitalAssetRewardDocument = RewardDocument & DigitalAssetRewardAttributes;

--- a/src/models/rewards.ts
+++ b/src/models/rewards.ts
@@ -1,5 +1,4 @@
 import mongoose, { Schema, model, Types, Document } from 'mongoose';
-
 import RewardTypes from '../constants/reward-types';
 
 export interface RewardAttributes {
@@ -41,23 +40,27 @@ const rewardSchema = new Schema<RewardAttributes>(
 export const RewardModel =
   mongoose.models.Reward || model<RewardAttributes>('Reward', rewardSchema);
 
-export const DigitalAssetRewardModel = RewardModel.discriminator<DigitalAssetRewardDocument>(
-  RewardTypes.DIGITAL_ASSET,
-  new Schema<DigitalAssetRewardAttributes>({
-    tokenId: { type: String, required: true },
-    blockchain: { type: String, required: true },
-    contractAddress: { type: String, required: true },
-  }),
-);
+if (!RewardModel.discriminators || !RewardModel.discriminators[RewardTypes.DIGITAL_ASSET]) {
+  RewardModel.discriminator<DigitalAssetRewardDocument>(
+    RewardTypes.DIGITAL_ASSET,
+    new Schema<DigitalAssetRewardAttributes>({
+      tokenId: { type: String, required: true },
+      blockchain: { type: String, required: true },
+      contractAddress: { type: String, required: true },
+    }),
+  );
+}
 
-export const InGameRewardModel = RewardModel.discriminator<InGameRewardDocument>(
-  RewardTypes.IN_GAME_ITEM,
-  new Schema<InGameRewardAttributes>({
-    power: Number,
-    rarity: String,
-    durability: String,
-  }),
-);
+if (!RewardModel.discriminators || !RewardModel.discriminators[RewardTypes.IN_GAME_ITEM]) {
+  RewardModel.discriminator<InGameRewardDocument>(
+    RewardTypes.IN_GAME_ITEM,
+    new Schema<InGameRewardAttributes>({
+      power: Number,
+      rarity: String,
+      durability: String,
+    }),
+  );
+}
 
 export type RewardDocument = Document & RewardAttributes;
 export type InGameRewardDocument = RewardDocument & InGameRewardAttributes;


### PR DESCRIPTION
## Description

This update introduces a fix to prevent Discriminator errors by ensuring that Mongoose discriminators are not redefined if they have already been registered. We added checks to utilize existing discriminators when they are already defined, improving the robustness of the data models, especially in environments with hot-reloading or dynamic imports (e.g., Next.js development mode).

These changes enhance the stability of the codebase, preventing errors due to multiple definitions of the same discriminators.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue with the data model)

## How Has This Been Tested?

The changes were tested by verifying that the data models no longer trigger Discriminator errors when imported multiple times across different modules. We ran the following tests:

- [ ] Unit tests for models
- [ ] Integration tests with related collections

**Test Configuration**:

- **MongoDB version**: 7.x
- **Mongoose version**: 8.x
- **Node.js version**: 20.x

## Checklist:

- [x] My code follows the style guidelines of this project (e.g., naming conventions for models, schemas, etc.)
- [x] I have performed a self-review of my own code
- [x] I have documented any changes to the data models or schema
- [x] My changes do not introduce new warnings
- [x] I have added tests that validate my changes to the data models
- [x] New and existing unit tests pass locally with my changes
- [x] Any necessary changes to downstream modules or related collections have been merged or communicated
